### PR TITLE
enhances button hover styles for improved accessibility

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -59,7 +59,7 @@
               variant="outline"
               size="sm"
               href="/modules"
-              class="w-full group-hover:bg-blue-50"
+              class="w-full group-hover:bg-blue-50 group-hover:text-blue-700 group-hover:border-blue-200"
             >
               Zur {defaultRoutes['/modules'].name}
             </Button>
@@ -86,7 +86,7 @@
               variant="outline"
               size="sm"
               href="/module-catalogs"
-              class="w-full group-hover:bg-green-50"
+              class="w-full group-hover:bg-green-50 group-hover:text-green-700 group-hover:border-green-200"
             >
               Zu den {defaultRoutes['/module-catalogs'].name}
             </Button>
@@ -113,7 +113,7 @@
               variant="outline"
               size="sm"
               href="/examination"
-              class="w-full group-hover:bg-purple-50"
+              class="w-full group-hover:bg-purple-50 group-hover:text-purple-700 group-hover:border-purple-200"
             >
               Zu den Prüfungslisten
             </Button>
@@ -140,7 +140,7 @@
               variant="outline"
               size="sm"
               href="/my-modules"
-              class="w-full group-hover:bg-orange-50"
+              class="w-full group-hover:bg-orange-50 group-hover:text-orange-700 group-hover:border-orange-200"
             >
               Zu meinen Modulen
             </Button>


### PR DESCRIPTION
This pull request updates the hover styles for buttons in the `src/routes/+page.svelte` file to enhance visual feedback. The changes add new hover effects for text color and border color, complementing the existing background color changes.

Styling updates for hover effects:

* Updated the button for the `/modules` route to include `group-hover:text-blue-700` and `group-hover:border-blue-200` styles.
* Updated the button for the `/module-catalogs` route to include `group-hover:text-green-700` and `group-hover:border-green-200` styles.
* Updated the button for the `/examination` route to include `group-hover:text-purple-700` and `group-hover:border-purple-200` styles.
* Updated the button for the `/my-modules` route to include `group-hover:text-orange-700` and `group-hover:border-orange-200` styles.