### PR TITLE
fix(ui): add dark mode support for prose content

### DIFF
--- a/src/routes/modules/[id=uuid]/(components)/module-detail.svelte
+++ b/src/routes/modules/[id=uuid]/(components)/module-detail.svelte
@@ -933,7 +933,7 @@
     </ToggleGroup.Root>
   </div>
 
-  <div class="prose max-w-none">
+  <div class="prose dark:prose-invert max-w-none">
     {#if selectedLanguage === 'en'}
       {@render markdown('Learning Outcome', module.enContent.learningOutcome)}
       {@render markdown('Module Content', module.enContent.moduleContent)}


### PR DESCRIPTION
- Apply prose-invert class for better dark theme readability
- Resolves text visibility issues in module detail view

This pull request includes a small change to the `module-detail.svelte` file. The change adds a `dark:prose-invert` class to ensure proper styling in dark mode. ([src/routes/modules/[id=uuid]/(components)/module-detail.svelteL936-R936](diffhunk://#diff-2c146e0432c858f86b7f957d9bc3dfc497a9c6696c49e86c31f0ef4db2bc06f6L936-R936))

Before:
<img width="300" height="auto" alt="localhost_5173_modules_692c58d7-f302-4dc7-821b-06cdcb6c18eb(iPhone 12 Pro)" src="https://github.com/user-attachments/assets/f99d122b-f512-4fc4-904a-e4d4907c6dd0" />

After:
<img width="300" height="auto" alt="localhost_5173_modules_692c58d7-f302-4dc7-821b-06cdcb6c18eb(iPhone 12 Pro) (1)" src="https://github.com/user-attachments/assets/0d557a93-26ce-46b8-b9ad-fae5a7284fef" />
