### PR TITLE
feat: Add legal footer links (Haftungshinweis & Datenschutz)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -262,8 +262,21 @@
         >
           Impressum
         </a>
-        <a href="/privacy" class="text-muted-foreground transition-colors hover:text-foreground">
-          Datenschutzerklärung
+        <a
+          href="https://www.th-koeln.de/hochschule/haftungshinweis_8277.php"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Haftungshinweis
+        </a>
+        <a
+          href="https://www.th-koeln.de/hochschule/datenschutzhinweis_8279.php"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Datenschutzhinweise
         </a>
         <a href="/help" class="text-muted-foreground transition-colors hover:text-foreground">
           Hilfe


### PR DESCRIPTION
This pull request updates the footer links in the `src/routes/+page.svelte` file to include external links for liability and privacy notices, replacing the previous internal privacy link.

### Footer link updates:
* Replaced the internal privacy link with two new external links: one for "Haftungshinweis" and another for "Datenschutzhinweise." Both links open in a new tab and include `rel="noopener noreferrer"` for security.