### PR TITLE
Feat/sidebar theme switcher

### DIFF
--- a/src/routes/app-sidebar.svelte
+++ b/src/routes/app-sidebar.svelte
@@ -5,6 +5,7 @@
   import type { ComponentProps } from 'svelte'
   import NavMenu from './nav-menu.svelte'
   import NavUserLogin from './nav-user-login.svelte'
+  import ToggleTheme from './nav-toggle-theme.svelte'
 
   let {
     ref = $bindable(null),
@@ -24,6 +25,7 @@
   </Sidebar.Content>
   <Sidebar.Footer>
     <NavUserLogin {user} {userInfo} />
+    <ToggleTheme />
   </Sidebar.Footer>
   <Sidebar.Rail />
 </Sidebar.Root>

--- a/src/routes/nav-toggle-theme.svelte
+++ b/src/routes/nav-toggle-theme.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import SunIcon from '@lucide/svelte/icons/sun'
+  import MoonIcon from '@lucide/svelte/icons/moon'
+
+  import { setMode, mode } from 'mode-watcher'
+  import * as Tabs from '$lib/components/ui/tabs/index.js'
+  import * as Sidebar from '$lib/components/ui/sidebar/index.js'
+</script>
+
+<Sidebar.Menu>
+  <Sidebar.MenuItem>
+    <Tabs.Root value={$mode} onValueChange={(value) => setMode(value)} class="w-full">
+      <Tabs.List class="grid w-full grid-cols-2">
+        <Tabs.Trigger value="light" class="flex items-center gap-2">
+          <SunIcon class="h-4 w-4" />
+          <span>Light</span>
+        </Tabs.Trigger>
+        <Tabs.Trigger value="dark" class="flex items-center gap-2">
+          <MoonIcon class="h-4 w-4" />
+          <span>Dark</span>
+        </Tabs.Trigger>
+      </Tabs.List>
+    </Tabs.Root>
+  </Sidebar.MenuItem>
+</Sidebar.Menu>

--- a/src/routes/nav-toggle-theme.svelte
+++ b/src/routes/nav-toggle-theme.svelte
@@ -9,13 +9,13 @@
 
 <Sidebar.Menu>
   <Sidebar.MenuItem>
-    <Tabs.Root value={$mode} onValueChange={(value) => setMode(value)} class="w-full">
-      <Tabs.List class="grid w-full grid-cols-2">
-        <Tabs.Trigger value="light" class="flex items-center gap-2">
+    <Tabs.Root value={$mode} onValueChange={(value) => setMode(value)}>
+      <Tabs.List class="grid h-9 w-full grid-cols-2 rounded-lg">
+        <Tabs.Trigger value="light" class="flex h-7 items-center gap-2 rounded-lg">
           <SunIcon class="h-4 w-4" />
           <span>Light</span>
         </Tabs.Trigger>
-        <Tabs.Trigger value="dark" class="flex items-center gap-2">
+        <Tabs.Trigger value="dark" class="flex h-7 items-center gap-2 rounded-lg">
           <MoonIcon class="h-4 w-4" />
           <span>Dark</span>
         </Tabs.Trigger>

--- a/src/routes/nav-toggle-theme.svelte
+++ b/src/routes/nav-toggle-theme.svelte
@@ -10,12 +10,12 @@
 <Sidebar.Menu>
   <Sidebar.MenuItem>
     <Tabs.Root value={$mode} onValueChange={(value) => setMode(value)}>
-      <Tabs.List class="grid h-9 w-full grid-cols-2 rounded-lg">
-        <Tabs.Trigger value="light" class="flex h-7 items-center gap-2 rounded-lg">
+      <Tabs.List class="grid w-full grid-cols-2 rounded-lg">
+        <Tabs.Trigger value="light" class="flex items-center gap-2 rounded-lg">
           <SunIcon class="h-4 w-4" />
           <span>Light</span>
         </Tabs.Trigger>
-        <Tabs.Trigger value="dark" class="flex h-7 items-center gap-2 rounded-lg">
+        <Tabs.Trigger value="dark" class="flex items-center gap-2 rounded-lg">
           <MoonIcon class="h-4 w-4" />
           <span>Dark</span>
         </Tabs.Trigger>


### PR DESCRIPTION
This pull request adds a theme toggle feature to the sidebar, allowing users to switch between light and dark modes. The implementation introduces a new `nav-toggle-theme.svelte` component and integrates it into the sidebar's footer.

**Theme toggle feature:**

* Added new `ToggleTheme` component (`nav-toggle-theme.svelte`) that provides UI controls for switching between light and dark modes using tabbed buttons.
* Imported and rendered the `ToggleTheme` component in the sidebar footer within `app-sidebar.svelte`, making the theme toggle accessible to users.

Closes #14 
Resolves #14 

<img width="247" height="auto" alt="image" src="https://github.com/user-attachments/assets/d32b9347-a33e-43d1-921c-fb208cd0a4ec" />
<img width="247" height="auto" alt="image" src="https://github.com/user-attachments/assets/4bdb63c3-b53f-4fe6-9d3c-2a8b242f1aef" />
<br/>
<img width="247" height="auto" alt="image" src="https://github.com/user-attachments/assets/64e06072-6c82-4f25-9b49-9ae521a2fcaa" />
<img width="247" height="auto" alt="image" src="https://github.com/user-attachments/assets/1103decf-a70b-432e-9ddf-79fcd20af54f" />
