### PR TITLE
style: update TLDR component styling for improved readability

### DIFF
--- a/src/routes/help/+page.svelte
+++ b/src/routes/help/+page.svelte
@@ -72,10 +72,10 @@
 </script>
 
 {#snippet TLDR(content: string)}
-  <div class="rounded border-l-2 border-l-gray-300 bg-gray-50/50 py-2 pl-3 pr-2 italic">
-    <div class="text-sm text-gray-600">
-      <span class="font-medium text-gray-700">TLDR:</span>
-      <span class="text-gray-500">{content}</span>
+  <div class="rounded border-l-2 border-l-muted-foreground/30 bg-muted/50 py-2 pl-3 pr-2 italic">
+    <div class="text-sm text-muted-foreground">
+      <span class="font-medium text-foreground">TLDR:</span>
+      <span class="text-muted-foreground">{content}</span>
     </div>
   </div>
 {/snippet}


### PR DESCRIPTION
This pull request makes a small update to the styling of the TLDR snippet in the `src/routes/help/+page.svelte` file. The change updates the color classes to use the new theme variables for muted foreground and background colors, improving consistency with the current design system.

before:
<img width="1705" height="1110" alt="Screenshot 2025-10-01 201608" src="https://github.com/user-attachments/assets/cbc8686b-bef9-4c59-a673-6b55126bbe62" />

after:
<img width="853" height="560" alt="image" src="https://github.com/user-attachments/assets/abefc3d9-6be0-40de-afd3-99d0233748af" />
