### PR TITLE
fix: docs page sticky sidebar

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
         <NavBreadcrumb />
       </div>
     </header>
-    <main class="flex-1 overflow-auto px-4 py-6">
+    <main class="flex-1 px-4 py-6">
       {@render children?.()}
     </main>
   </Sidebar.Inset>

--- a/src/routes/help/+page.svelte
+++ b/src/routes/help/+page.svelte
@@ -197,7 +197,7 @@
     </main>
 
     <!-- Navigation Sidebar -->
-    <aside class="sticky hidden w-64 flex-shrink-0 self-start lg:block">
+    <aside class="sticky top-6 hidden w-64 flex-shrink-0 self-start lg:block">
       <div class="max-h-[calc(100vh-4rem)] overflow-y-auto rounded-lg border bg-card p-4 shadow-sm">
         <nav class="space-y-1">
           <div class="mb-6 border-b border-border pb-3">


### PR DESCRIPTION
Issue #27 

Sidebar is now sticking, the issue was the `overflow-auto` that created a new scrolling area for the main content. The sticky sidebar could only stick relative to the <main> container, not the overall browser window.

Additionally, `top-6` is defining *where* the element should stick.

Before:

<img width="1447" height="314" alt="Bildschirmfoto 2025-10-04 um 19 18 47" src="https://github.com/user-attachments/assets/629ce2a8-3acf-4f25-afee-1eeaee0aacc4" />

After:

<img width="1440" height="409" alt="Bildschirmfoto 2025-10-04 um 19 19 14" src="https://github.com/user-attachments/assets/5b07d3f7-912c-4e4c-9849-4c0a99a5492c" />
