### PR TITLE
License and Trademark Policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 THK-ADV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,9 @@
+# Trademark Policy
+
+`THK-ADV`, project names, and logos used by this project are trademarks or identifiers of their respective owners.
+
+This repository is licensed under MIT for the source code. The MIT license does not grant rights to use project names, logos, or branding in a way that suggests endorsement or official affiliation.
+
+You may use names and logos only for accurate, non-misleading reference (for example, "based on THK-ADV modules").
+
+If you want to use project branding for promotion, distribution, or product naming, request permission from the maintainers first.


### PR DESCRIPTION
- add an MIT `LICENSE` file for the frontend repository
- add `TRADEMARK.md` to clarify name/logo usage separate from code licensing
- keep legal metadata aligned with the backend repository