### PR TITLE
Module Catalog Intro Upload Bug Fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@
 services:
   frontend:
     env_file: .env.production
+    environment:
+      BODY_SIZE_LIMIT: 10M
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/routes/actions/module-catalog/+server.ts
+++ b/src/routes/actions/module-catalog/+server.ts
@@ -13,28 +13,29 @@ export const POST: RequestHandler = async ({ request, fetch, url }) => {
     return error(400, { message: 'studyProgramId und poId sind erforderlich' })
   }
 
-  try {
-    const requestInit: RequestInit & { duplex: string } = {
-      method: 'POST',
-      headers: request.headers,
-      body: request.body,
-      duplex: 'half'
-    }
-    const response = await fetch(
-      `/auth-api/moduleCatalogIntros/${studyProgramId}/${poId}`,
-      requestInit
-    )
+  const headers = new Headers()
+  const contentType = request.headers.get('content-type')
+  if (contentType) headers.set('content-type', contentType)
+  const body = await request.arrayBuffer()
 
-    if (!response.ok) {
-      const err = await response.json()
-      return error(response.status, {
-        message: err.message || 'Fehler beim Hochladen der Einleitung'
-      })
-    }
-
-    return json({ success: true }, { status: 200 })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    return error(500, { message })
+  const requestInit: RequestInit = {
+    method: 'POST',
+    headers,
+    body
   }
+  const response = await fetch(
+    `/auth-api/moduleCatalogIntros/${studyProgramId}/${poId}`,
+    requestInit
+  )
+
+  if (!response.ok) {
+    const err = await response
+      .json()
+      .catch(() => ({ message: 'Fehler beim Hochladen der Einleitung' }))
+    throw error(response.status, {
+      message: err.message || 'Fehler beim Hochladen der Einleitung'
+    })
+  }
+
+  return json({ success: true }, { status: 200 })
 }

--- a/src/routes/studyprogram/(components)/module-catalog-upload-intro-dialog.svelte
+++ b/src/routes/studyprogram/(components)/module-catalog-upload-intro-dialog.svelte
@@ -136,6 +136,7 @@
         <p class="font-semibold">Anforderungen:</p>
         <ul class="list-disc space-y-1 pl-5">
           <li>Nur <span class="font-semibold">Word-Dateien (.docx)</span> werden akzeptiert</li>
+          <li>Die maximale Dateigröße beträgt <span class="font-semibold">10 MB</span></li>
           <li>Alle enthaltenen Bilder müssen im PNG-Format sein</li>
           <li>Die "Überschrift 1" darf mehrfach vorkommen</li>
         </ul>


### PR DESCRIPTION
## Summary
- Fix module catalog intro upload handling in production by forwarding a safe request body/header set in the action proxy.
- Configure frontend runtime `BODY_SIZE_LIMIT=10M` so uploads above the default 512KB limit are accepted.
- Add the 10 MB file size requirement to the upload dialog text.