### PR TITLE
Add AGENTS.md with cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is **MOCOGi** — a SvelteKit 5 frontend for managing module descriptions, module catalogs, and exam lists at TH Köln, Campus Gummersbach (Faculty 10). It is a **frontend-only** app that proxies API requests to an external backend.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `pnpm install` |
+| Dev server | `pnpm dev` (port 5173) |
+| Lint | `pnpm lint` |
+| Type check | `pnpm check` |
+| Build | `pnpm build` |
+
+### Architecture notes
+
+- **No local database or backend** — all data comes from the external API at `BACKEND_URL_PREFIX` (configured in `.env.development`).
+- **API proxy** in `src/hooks.server.ts`: `/api/*` routes proxy unauthenticated to the backend; `/auth-api/*` proxies with a Bearer token.
+- **Authentication** uses Keycloak OIDC (server-side authorization code flow with PKCE). Tokens stored as httpOnly cookies (`kc-access`, `kc-refresh`).
+- **Public routes** (no auth needed): `/`, `/modules`, `/module-catalogs`, `/exam-lists`, `/schedule`, `/help`, `/release-notes`, `/assessment-methods`.
+- **Protected routes** (require Keycloak login): `/my-modules`, `/module-approvals`, `/studyprogram`, `/schedule-planning`, `/settings`.
+
+### Known issues (pre-existing)
+
+- `pnpm lint` reports 1 ESLint error in `src/lib/components/forms/date-time-picker.svelte` (svelte/prefer-svelte-reactivity).
+- `pnpm check` reports 11 type errors (mostly in `schedule-entry-edit-dialog.svelte` and a missing env export in release-notes).
+- `pnpm build` fails because `$env/static/private` vars are not available at build time without a real `.env` file. The dev server (`pnpm dev`) works correctly because it reads from `.env.development`.
+
+### Dev server startup
+
+Run `pnpm dev`. The first request may take a few seconds as Vite optimizes dependencies. The server connects to remote backend/Keycloak endpoints defined in `.env.development` — no local services need to be running.
+
+### No test suite
+
+This project does not have any automated tests configured (no vitest, playwright, or cypress).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment documentation for Cursor Cloud agents.

## Changes

- Created `AGENTS.md` with cloud-specific instructions including:
  - Key commands for development (install, dev, lint, check, build)
  - Architecture notes (API proxy, auth flow, public vs protected routes)
  - Known pre-existing issues (lint error, type errors, build env vars)
  - Dev server startup notes
  - Note about no test suite being configured

## Demo

[demo_module_search_and_view.mp4](https://cursor.com/agents/bc-c70607f2-1a2f-47b3-aa4c-e7ebbe58b711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_module_search_and_view.mp4)

The development environment is fully functional — the SvelteKit dev server starts successfully, serves pages, proxies to the remote backend API, and supports interactive module search and viewing.

[Module search results for Programmierung](https://cursor.com/agents/bc-c70607f2-1a2f-47b3-aa4c-e7ebbe58b711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_results.webp)
[Module detail page for Mathematik](https://cursor.com/agents/bc-c70607f2-1a2f-47b3-aa4c-e7ebbe58b711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmodule_detail_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c70607f2-1a2f-47b3-aa4c-e7ebbe58b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70607f2-1a2f-47b3-aa4c-e7ebbe58b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

