### PR TITLE
Filter schedule views by lecturer instead of module manager

### DIFF
--- a/src/lib/components/schedule/schedule-filter.svelte
+++ b/src/lib/components/schedule/schedule-filter.svelte
@@ -22,8 +22,9 @@
       selectedModules,
       selectedStudyPrograms,
       selectedSemesters,
-      selectedIdentities,
+      selectedLecturers,
       selectedModuleManagers,
+      showModuleManagementFilter,
       selectedRooms,
       selectedModuleTypes
     } = scheduleFilter
@@ -35,8 +36,8 @@
       selectedModules.length > 0 ||
       selectedStudyPrograms.length > 0 ||
       selectedSemesters.length > 0 ||
-      selectedIdentities.length > 0 ||
-      selectedModuleManagers.length > 0 ||
+      selectedLecturers.length > 0 ||
+      (showModuleManagementFilter && selectedModuleManagers.length > 0) ||
       selectedRooms.length > 0 ||
       selectedModuleTypes.length > 0
     )
@@ -65,8 +66,9 @@
       selectedModules,
       selectedStudyPrograms,
       selectedSemesters,
-      selectedIdentities,
+      selectedLecturers,
       selectedModuleManagers,
+      showModuleManagementFilter,
       selectedRooms,
       selectedModuleTypes
     } = scheduleFilter
@@ -87,10 +89,10 @@
     if (selectedSemesters.length > 0) {
       count++
     }
-    if (selectedIdentities.length > 0) {
+    if (selectedLecturers.length > 0) {
       count++
     }
-    if (selectedModuleManagers.length > 0) {
+    if (showModuleManagementFilter && selectedModuleManagers.length > 0) {
       count++
     }
     if (selectedRooms.length > 0) {
@@ -196,11 +198,11 @@
     />
   {/if}
   <FilterOption
-    filterValues={scheduleFilter.selectedIdentities}
-    handleSelect={scheduleFilter.selectIdentity}
+    filterValues={scheduleFilter.selectedLecturers}
+    handleSelect={scheduleFilter.selectLecturer}
     title="Dozierende"
     options={scheduleFilter.identities}
-    clearFilters={scheduleFilter.clearSelectedIdentities}
+    clearFilters={scheduleFilter.clearSelectedLecturers}
   />
   <FilterOption
     filterValues={scheduleFilter.selectedRooms}

--- a/src/lib/components/schedule/schedule-filter.svelte
+++ b/src/lib/components/schedule/schedule-filter.svelte
@@ -183,7 +183,7 @@
   <FilterOption
     filterValues={scheduleFilter.selectedIdentities}
     handleSelect={scheduleFilter.selectIdentity}
-    title="Modulverantwortliche"
+    title="Dozierende"
     options={scheduleFilter.identities}
     clearFilters={scheduleFilter.clearSelectedIdentities}
   />

--- a/src/lib/components/schedule/schedule-filter.svelte
+++ b/src/lib/components/schedule/schedule-filter.svelte
@@ -23,6 +23,7 @@
       selectedStudyPrograms,
       selectedSemesters,
       selectedIdentities,
+      selectedModuleManagers,
       selectedRooms,
       selectedModuleTypes
     } = scheduleFilter
@@ -35,6 +36,7 @@
       selectedStudyPrograms.length > 0 ||
       selectedSemesters.length > 0 ||
       selectedIdentities.length > 0 ||
+      selectedModuleManagers.length > 0 ||
       selectedRooms.length > 0 ||
       selectedModuleTypes.length > 0
     )
@@ -64,6 +66,7 @@
       selectedStudyPrograms,
       selectedSemesters,
       selectedIdentities,
+      selectedModuleManagers,
       selectedRooms,
       selectedModuleTypes
     } = scheduleFilter
@@ -85,6 +88,9 @@
       count++
     }
     if (selectedIdentities.length > 0) {
+      count++
+    }
+    if (selectedModuleManagers.length > 0) {
       count++
     }
     if (selectedRooms.length > 0) {
@@ -180,6 +186,15 @@
     options={scheduleFilter.courseTypes}
     clearFilters={scheduleFilter.clearSelectedCourseTypes}
   />
+  {#if scheduleFilter.showModuleManagementFilter}
+    <FilterOption
+      filterValues={scheduleFilter.selectedModuleManagers}
+      handleSelect={scheduleFilter.selectModuleManager}
+      title="Modulverantwortliche"
+      options={scheduleFilter.identities}
+      clearFilters={scheduleFilter.clearSelectedModuleManagers}
+    />
+  {/if}
   <FilterOption
     filterValues={scheduleFilter.selectedIdentities}
     handleSelect={scheduleFilter.selectIdentity}

--- a/src/lib/components/schedule/schedule.svelte
+++ b/src/lib/components/schedule/schedule.svelte
@@ -128,11 +128,11 @@
           }
         }
 
-        // Identities filter
+        // Lecturers filter
         if (selectedIdentities.length > 0) {
           if (
             !selectedIdentities.some((id) =>
-              entry.extendedProps.raw.moduleManagement.some((m) => m.id === id)
+              entry.extendedProps.raw.lecturer.some((m) => m.id === id)
             )
           ) {
             continue

--- a/src/lib/components/schedule/schedule.svelte
+++ b/src/lib/components/schedule/schedule.svelte
@@ -64,8 +64,9 @@
         selectedModules,
         selectedStudyPrograms,
         selectedSemesters,
-        selectedIdentities,
+        selectedLecturers,
         selectedModuleManagers,
+        showModuleManagementFilter,
         selectedRooms,
         selectedModuleTypes,
         searchString
@@ -129,8 +130,8 @@
           }
         }
 
-        // Module managers filter (schedule view only; planning keeps this empty)
-        if (selectedModuleManagers.length > 0) {
+        // Module managers filter
+        if (showModuleManagementFilter && selectedModuleManagers.length > 0) {
           if (
             !selectedModuleManagers.some((id) =>
               entry.extendedProps.raw.moduleManagement.some((m) => m.id === id)
@@ -141,9 +142,9 @@
         }
 
         // Lecturers filter
-        if (selectedIdentities.length > 0) {
+        if (selectedLecturers.length > 0) {
           if (
-            !selectedIdentities.some((id) =>
+            !selectedLecturers.some((id) =>
               entry.extendedProps.raw.lecturer.some((m) => m.id === id)
             )
           ) {

--- a/src/lib/components/schedule/schedule.svelte
+++ b/src/lib/components/schedule/schedule.svelte
@@ -65,6 +65,7 @@
         selectedStudyPrograms,
         selectedSemesters,
         selectedIdentities,
+        selectedModuleManagers,
         selectedRooms,
         selectedModuleTypes,
         searchString
@@ -124,6 +125,17 @@
           )
 
           if (matchingPoEntries.length === 0) {
+            continue
+          }
+        }
+
+        // Module managers filter (schedule view only; planning keeps this empty)
+        if (selectedModuleManagers.length > 0) {
+          if (
+            !selectedModuleManagers.some((id) =>
+              entry.extendedProps.raw.moduleManagement.some((m) => m.id === id)
+            )
+          ) {
             continue
           }
         }

--- a/src/lib/stores/schedule-filter.svelte.ts
+++ b/src/lib/stores/schedule-filter.svelte.ts
@@ -76,6 +76,10 @@ export function createScheduleFilter(prefix: FilterType) {
   let selectedIdentities: string[] = $state(
     getArrayFromLocalStorage(`${prefix}-selected-lecturers`)
   )
+  // Only used on the public schedule view (`sf`); planning keeps this empty.
+  let selectedModuleManagers: string[] = $state(
+    prefix === 'sf' ? getArrayFromLocalStorage(`${prefix}-selected-module-managers`) : []
+  )
   let selectedRooms: string[] = $state(getArrayFromLocalStorage(`${prefix}-selected-rooms`))
   let selectedModuleTypes: string[] = $state(
     getArrayFromLocalStorage(`${prefix}-selected-module-types`)
@@ -221,6 +225,24 @@ export function createScheduleFilter(prefix: FilterType) {
       selectedIdentities = []
       clearItemFromLocalStorage(`${prefix}-selected-lecturers`)
     },
+    get selectedModuleManagers() {
+      return selectedModuleManagers
+    },
+    selectModuleManager(id: string) {
+      if (selectedModuleManagers.includes(id)) {
+        selectedModuleManagers = selectedModuleManagers.filter((x) => x !== id)
+      } else {
+        selectedModuleManagers = [...selectedModuleManagers, id]
+      }
+      setArrayToLocalStorage(`${prefix}-selected-module-managers`, selectedModuleManagers)
+    },
+    clearSelectedModuleManagers() {
+      selectedModuleManagers = []
+      clearItemFromLocalStorage(`${prefix}-selected-module-managers`)
+    },
+    get showModuleManagementFilter() {
+      return prefix === 'sf'
+    },
     get rooms() {
       return rooms
     },
@@ -269,6 +291,7 @@ export function createScheduleFilter(prefix: FilterType) {
       this.clearSelectedStudyPrograms()
       this.clearSelectedSemesters()
       this.clearSelectedIdentities()
+      this.clearSelectedModuleManagers()
       this.clearSelectedRooms()
       this.clearSelectedModuleTypes()
     },

--- a/src/lib/stores/schedule-filter.svelte.ts
+++ b/src/lib/stores/schedule-filter.svelte.ts
@@ -74,7 +74,7 @@ export function createScheduleFilter(prefix: FilterType) {
   )
   let selectedSemesters: string[] = $state(getArrayFromLocalStorage(`${prefix}-selected-semesters`))
   let selectedIdentities: string[] = $state(
-    getArrayFromLocalStorage(`${prefix}-selected-identities`)
+    getArrayFromLocalStorage(`${prefix}-selected-lecturers`)
   )
   let selectedRooms: string[] = $state(getArrayFromLocalStorage(`${prefix}-selected-rooms`))
   let selectedModuleTypes: string[] = $state(
@@ -215,11 +215,11 @@ export function createScheduleFilter(prefix: FilterType) {
       } else {
         selectedIdentities = [...selectedIdentities, id]
       }
-      setArrayToLocalStorage(`${prefix}-selected-identities`, selectedIdentities)
+      setArrayToLocalStorage(`${prefix}-selected-lecturers`, selectedIdentities)
     },
     clearSelectedIdentities() {
       selectedIdentities = []
-      clearItemFromLocalStorage(`${prefix}-selected-identities`)
+      clearItemFromLocalStorage(`${prefix}-selected-lecturers`)
     },
     get rooms() {
       return rooms

--- a/src/lib/stores/schedule-filter.svelte.ts
+++ b/src/lib/stores/schedule-filter.svelte.ts
@@ -49,6 +49,7 @@ export function createScheduleFilter(prefix: FilterType) {
   let showSemester = $state(getShowSemesterPlanFromLocalStorage(prefix))
   let showSchedule = $state(getShowScheduleFromLocalStorage(prefix))
   let showExams = $state(false)
+  const showModuleManagementFilter = prefix === 'sf'
 
   // Filter options
   let teachingUnits: FilterData[] = $state.raw([])
@@ -73,12 +74,13 @@ export function createScheduleFilter(prefix: FilterType) {
     getArrayFromLocalStorage(`${prefix}-selected-study-programs`)
   )
   let selectedSemesters: string[] = $state(getArrayFromLocalStorage(`${prefix}-selected-semesters`))
-  let selectedIdentities: string[] = $state(
+  let selectedLecturers: string[] = $state(
     getArrayFromLocalStorage(`${prefix}-selected-lecturers`)
   )
-  // Only used on the public schedule view (`sf`); planning keeps this empty.
   let selectedModuleManagers: string[] = $state(
-    prefix === 'sf' ? getArrayFromLocalStorage(`${prefix}-selected-module-managers`) : []
+    showModuleManagementFilter
+      ? getArrayFromLocalStorage(`${prefix}-selected-module-managers`)
+      : []
   )
   let selectedRooms: string[] = $state(getArrayFromLocalStorage(`${prefix}-selected-rooms`))
   let selectedModuleTypes: string[] = $state(
@@ -210,25 +212,26 @@ export function createScheduleFilter(prefix: FilterType) {
     get identities() {
       return identities
     },
-    get selectedIdentities() {
-      return selectedIdentities
+    get selectedLecturers() {
+      return selectedLecturers
     },
-    selectIdentity(id: string) {
-      if (selectedIdentities.includes(id)) {
-        selectedIdentities = selectedIdentities.filter((x) => x !== id)
+    selectLecturer(id: string) {
+      if (selectedLecturers.includes(id)) {
+        selectedLecturers = selectedLecturers.filter((x) => x !== id)
       } else {
-        selectedIdentities = [...selectedIdentities, id]
+        selectedLecturers = [...selectedLecturers, id]
       }
-      setArrayToLocalStorage(`${prefix}-selected-lecturers`, selectedIdentities)
+      setArrayToLocalStorage(`${prefix}-selected-lecturers`, selectedLecturers)
     },
-    clearSelectedIdentities() {
-      selectedIdentities = []
+    clearSelectedLecturers() {
+      selectedLecturers = []
       clearItemFromLocalStorage(`${prefix}-selected-lecturers`)
     },
     get selectedModuleManagers() {
       return selectedModuleManagers
     },
     selectModuleManager(id: string) {
+      if (!showModuleManagementFilter) return
       if (selectedModuleManagers.includes(id)) {
         selectedModuleManagers = selectedModuleManagers.filter((x) => x !== id)
       } else {
@@ -237,11 +240,12 @@ export function createScheduleFilter(prefix: FilterType) {
       setArrayToLocalStorage(`${prefix}-selected-module-managers`, selectedModuleManagers)
     },
     clearSelectedModuleManagers() {
+      if (!showModuleManagementFilter) return
       selectedModuleManagers = []
       clearItemFromLocalStorage(`${prefix}-selected-module-managers`)
     },
     get showModuleManagementFilter() {
-      return prefix === 'sf'
+      return showModuleManagementFilter
     },
     get rooms() {
       return rooms
@@ -290,7 +294,7 @@ export function createScheduleFilter(prefix: FilterType) {
       this.clearSelectedModules()
       this.clearSelectedStudyPrograms()
       this.clearSelectedSemesters()
-      this.clearSelectedIdentities()
+      this.clearSelectedLecturers()
       this.clearSelectedModuleManagers()
       this.clearSelectedRooms()
       this.clearSelectedModuleTypes()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a **Dozierende** filter that matches schedule entries by `lecturer`
- Keep **Modulverantwortliche** (match by `moduleManagement`) on the public `/schedule` view only
- Planning views show the lecturer filter only
- Persist lecturer selections under `*-selected-lecturers` and module-manager selections under `*-selected-module-managers`

## Approach
- Reuse the shared identity options list for both person filters
- Gate module-manager UI, selection, reset counting, and event filtering via `showModuleManagementFilter` (`prefix === 'sf'`)
- Lecturer selection API is named explicitly (`selectedLecturers` / `selectLecturer` / `clearSelectedLecturers`)
- Both filters are independent and AND-combined when active

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbc32-f234-7a0e-81e8-b40d7cb06d68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbc32-f234-7a0e-81e8-b40d7cb06d68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

